### PR TITLE
Zosuladenie zoznamu stlpcov s README.md a test_data.csv

### DIFF
--- a/grouper/priprava_dat.py
+++ b/grouper/priprava_dat.py
@@ -6,10 +6,12 @@ from grouper.pomocne_funkcie import zjednot_kod
 NAZVY_STLPCOV = [
     "id",
     "vek",
+    "vek_dni",
     "hmotnost",
     "umela_plucna_ventilacia",
     "diagnozy",
     "vykony",
+    "odbornosti",
     "drg",
 ]
 


### PR DESCRIPTION
Pred zmenou : 
```
OSN-Algoritmus-MS-2024$ python3 main.py --vyhodnot_neuplne_pripady test_data.csv 

Aktivovaný prepínač 'Vyhodnoť neúplné prípady'. V prípade, že nie je vyplnená nejaká povinná hodnota, aj tak sa bude pokračovať vo vyhodnocovaní.
WARNING: HP S49-05 nemá správne vyplnenú hmotnosť.
Traceback (most recent call last):
  File "main.py", line 107, in <module>
    grouper_ms(args.data_path, args.vsetky_vykony_hlavne, args.vyhodnot_neuplne_pripady)
  File "main.py", line 81, in grouper_ms
    writer.writerow(hospitalizacny_pripad)
  File "/home/vlk/miniconda3/lib/python3.8/csv.py", line 154, in writerow
    return self.writer.writerow(self._dict_to_list(rowdict))
  File "/home/vlk/miniconda3/lib/python3.8/csv.py", line 149, in _dict_to_list
    raise ValueError("dict contains fields not in fieldnames: "
ValueError: dict contains fields not in fieldnames: None
```

Po zmenene:

```
OSN-Algoritmus-MS-2024$ python3 main.py --vyhodnot_neuplne_pripady test_data.csv 
Aktivovaný prepínač 'Vyhodnoť neúplné prípady'. V prípade, že nie je vyplnená nejaká povinná hodnota, aj tak sa bude pokračovať vo vyhodnocovaní.
WARNING: HP 20224300000417 nemá vyplnenú ani jednu diagnózu.
WARNING: HP 8834_22000030 nemá správne vyplnený vek.

```