### PR TITLE
Ponechaj duplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pri spúšťaní programu je možné pridať príznaky, ktoré ovplyvňujú, ako
 
 `--vyhodnot_neuplne_pripady`, `-n` spôsobí, že aj v prípade, keď nie je vyplnená nejaká povinná hodnota, algoritmus pokračuje vo vyhodnocovaní daného prípadu. Bez tohto príznaku vráti hodnotu 'ERROR'.
 
-`--ponechaj_duplicity`, `-d`: spôsobí, že vo výstupnom zozname medicínskych služieb ponechaj aj duplicitné záznamy.
+`--ponechaj_duplicity`, `-d`: spôsobí, že vo výstupnom zozname medicínskych služieb zostanú ponechané aj duplicitné záznamy.
 
 ### Popis vstupného súboru
 Vstupný súbor musí byť vo formáte csv, kde každý riadok reprezentuje jeden hospitalizačný prípad. Oddeľovačom je bodkodčiarka `;`.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Pri spúšťaní programu je možné pridať príznaky, ktoré ovplyvňujú, ako
 
 `--vyhodnot_neuplne_pripady`, `-n` spôsobí, že aj v prípade, keď nie je vyplnená nejaká povinná hodnota, algoritmus pokračuje vo vyhodnocovaní daného prípadu. Bez tohto príznaku vráti hodnotu 'ERROR'.
 
+`--ponechaj_duplicity`, `-d`: spôsobí, že vo výstupnom zozname medicínskych služieb ponechaj aj duplicitné záznamy.
+
 ### Popis vstupného súboru
 Vstupný súbor musí byť vo formáte csv, kde každý riadok reprezentuje jeden hospitalizačný prípad. Oddeľovačom je bodkodčiarka `;`.
 

--- a/grouper/vyhodnotenie_priloh.py
+++ b/grouper/vyhodnotenie_priloh.py
@@ -515,8 +515,6 @@ def prirad_ms(hp, vsetky_vykony_hlavne):
 
     Pokiaľ hospitalizačný prípad nezapadá do žiadnej medicínskej služby podľa príloh, je mu priradená služba S99-99.
 
-    Na konci nájdené medicínske služby deduplikuj a vytvor z nich zoznam oddelený znakom ~.
-
     Args:
         hp (dict): hospitalizačný prípad
         vsetky_vykony_hlavne (bool): skúša všetky možné hlavné výkony
@@ -568,7 +566,4 @@ def prirad_ms(hp, vsetky_vykony_hlavne):
     if not services:
         services = ["S99-99"]
 
-    # deduplikuj medicinske sluzby
-    services = list(dict.fromkeys(services))
-
-    return "~".join(services)
+    return services

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ Args:
     file_path: Relatívna cesta k súboru s dátami.
     --vsetky_vykony_hlavne, -v: Pri vyhodnotení príloh predpokladaj, že ktorýkoľvek z výkazaných výkonov mohol byť hlavný.
     --vyhodnot_neuplne_pripady, -n: V prípade, že nie je vyplnená nejaká povinná hodnota, aj tak pokračuj vo vyhodnocovaní. Štandardne vráti hodnotu 'ERROR'.
+    --ponechaj_duplicity, -d: Vo výstupnom zozname medicínskych služieb ponechaj aj duplicitné záznamy.
 
 Returns:
     None
@@ -17,9 +18,9 @@ Examples:
     # Spustenie so zapnutým prepínačom na vyhodnotenie aj neúplných prípadov
     python3 ./main.py ./test_data.csv --vyhodnot_neuplne_pripady
     # Spustenie so všetkými prepínačmi zapnutými
-    python3 ./main.py ./test_data.csv -vn
+    python3 ./main.py ./test_data.csv -vnd
     # Spustenie na Windows
-    python .\main.py .\test_data_phsk_2.csv -vn
+    python .\main.py .\test_data_phsk_2.csv -vnd
 """
 
 import argparse


### PR DESCRIPTION
Pridanie prepínača na ponechanie duplicít.

Bez použitia prepínača (default) je správanie rovnaké, ako doteraz.

Pokiaľ sa použije prepínač, preskočí sa krok deduplikácie zoznamu nájdených medicínskych služieb.

Presunul som deduplikáciu z 'vyhodnotenie_priloh' do 'main'.

Testované na dátach 2023.